### PR TITLE
 aws-java-sdk from 1.3.11  to 1.3.14

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject dynamo4clj "1.0.11"
+(defproject dynamo4clj "1.0.12"
   :description "Amazon DynamoDB API"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.amazonaws/aws-java-sdk "1.3.11"]
+                 [com.amazonaws/aws-java-sdk "1.3.14"]
                  [org.clojure/algo.generic "0.1.0"]]
   :dev-dependencies [[swank-clojure "1.4.0"]
                     [yij/lein-plugins "1.0.5"]]


### PR DESCRIPTION
updating aws-java-sdk from 1.3.11  to 1.3.14 since 1.3.11 is giving dependency issues. 
Lein deps showed:
Check :dependencies and :repositories for typos.
It's possible the specified jar is not in any repository.
If so, see "Free-floating Jars" under http://j.mp/repeatability
